### PR TITLE
Execute with bash, other minor polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ To get started, simply grant a permission to execute the file, and you can run i
       -t  (%integer%)     Set the interval for the data update. Default is 1.
       -v                  Prints version number.
       -h                  Prints help.
-    
+
+### Dependencies
+
+bash, calc, grep, and awk are required for the script to run.
+
 ## Example
 **Using the minimum requirements**
 

--- a/nettraffic
+++ b/nettraffic
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+hash calc 2>/dev/null || { echo >&2 "calc is required but not installed, aborting."; exit 1; }
 
 NAME="nettrafic"
 VERSION="0.3.4"


### PR DESCRIPTION
Summary:
* Require execution of bash due to bash-style conditional syntax.
* Check for calc program before execution.
* Document dependencies in README.

On my computer, the script fails to execute with the following because /bin/sh does not understand /bin/bash syntax:
```
$ ./nettraffic -i wlp4s0
./nettraffic: 55: [[: not found
./nettraffic: 60: [[: not found
./nettraffic: 76: [[: not found
...
```

After changing the script to use bash and installing the required program `calc` I was able to run the script.